### PR TITLE
Use Volta to pin node, yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "setupFilesAfterEnv": [
       "./jest.setup.js"
     ]
+  },
+  "volta": {
+    "node": "14.16.0",
+    "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
Use Volta (https://volta.sh/) to pin node and yarn versions. If end-user doesn't have volta installed, this part of package.json is just ignored, it will not cause them any issues.