### PR TITLE
DRY refactor GithubMetrics report methods

### DIFF
--- a/src/github-metrics.ts
+++ b/src/github-metrics.ts
@@ -1,6 +1,6 @@
 import GithubClient from './github-client';
 import RepositoryReport from './reports/repository';
-import { generateDateRange, Period } from './utils/date';
+import { DateRange, generateDateRange, Period } from './utils/date';
 
 export default class GithubMetrics {
   #githubClient;
@@ -9,14 +9,16 @@ export default class GithubMetrics {
     this.#githubClient = new GithubClient({ token });
   }
 
-  async generateDailyReport({
+  async generateReport({
     owner,
     repo,
+    dateRange,
   }: {
     owner: string;
     repo: string;
-  }): Promise<RepositoryReport> {
-    const { startDate, endDate } = generateDateRange();
+    dateRange: DateRange;
+  }) {
+    const { startDate, endDate } = dateRange;
     const pullRequests = await this.#githubClient.getPullRequestsByPeriod({
       owner,
       repo,
@@ -30,6 +32,20 @@ export default class GithubMetrics {
       repo,
       startDate: startDate.toISODate(),
       endDate: endDate.toISODate(),
+    });
+  }
+
+  async generateDailyReport({
+    owner,
+    repo,
+  }: {
+    owner: string;
+    repo: string;
+  }): Promise<RepositoryReport> {
+    return this.generateReport({
+      owner,
+      repo,
+      dateRange: generateDateRange(Period.DAY),
     });
   }
 
@@ -40,20 +56,10 @@ export default class GithubMetrics {
     owner: string;
     repo: string;
   }): Promise<RepositoryReport> {
-    const { startDate, endDate } = generateDateRange(Period.WEEK);
-    const pullRequests = await this.#githubClient.getPullRequestsByPeriod({
+    return this.generateReport({
       owner,
       repo,
-      startDate: startDate.toString(),
-      endDate: endDate.toString(),
-    });
-
-    return new RepositoryReport({
-      pullRequests,
-      owner,
-      repo,
-      startDate: startDate.toISODate(),
-      endDate: endDate.toISODate(),
+      dateRange: generateDateRange(Period.WEEK),
     });
   }
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -6,9 +6,12 @@ export enum Period {
   MONTH = 'month',
 }
 
-export function generateDateRange(
-  period = Period.DAY
-): { startDate: DateTime; endDate: DateTime } {
+export type DateRange = {
+  startDate: DateTime;
+  endDate: DateTime;
+};
+
+export function generateDateRange(period = Period.DAY): DateRange {
   const today = DateTime.now();
 
   const startDate = today.startOf(period);


### PR DESCRIPTION
Remove the duplication in the `generateXReport` methods and make it easier to generate reports for a custom time period.