### PR TITLE
Add MergedPRsMetric

### DIFF
--- a/src/metrics/merged-prs.ts
+++ b/src/metrics/merged-prs.ts
@@ -1,0 +1,33 @@
+import { Interval } from 'luxon';
+import { fetchMergedPullRequestNumbers } from '../utils/graphql-queries';
+import debug, { Debugger } from '../utils/debug';
+import { Metric, MetricData } from '../metric';
+import { pluralize } from '../utils/pluralize';
+
+export default class MergedPRsMetric implements Metric {
+  debug: Debugger;
+  data: MetricData[];
+  didRun: boolean = false;
+  name = 'Merged Pull Requests';
+  constructor(public interval: Interval) {
+    this.debug = debug.extend('metrics:merged-prs');
+    this.data = [];
+  }
+
+  get summary(): string {
+    if (!this.didRun) {
+      throw new Error(`Must run metric before accessing data`);
+    }
+    let count = this.data.length;
+    return `${count} merged pull ${pluralize('request', count)}`;
+  }
+
+  async run(): Promise<void> {
+    let numbers = await fetchMergedPullRequestNumbers(this.interval);
+    this.debug(`found merged PR numbers: %o`, numbers);
+
+    let data: MetricData[] = numbers.map((number) => ({ value: number }));
+    this.data = data;
+    this.didRun = true;
+  }
+}

--- a/src/reports/repository.ts
+++ b/src/reports/repository.ts
@@ -82,15 +82,6 @@ export default class RepositoryReport {
   }
 
   /**
-   * The number of merged pull requests.
-   */
-  get mergedPullRequests(): Array<PullRequest> {
-    return this.#pullRequests.filter(
-      (pr) => pr.state === PullRequestState.MERGED
-    );
-  }
-
-  /**
    * The number of opened and merged pull requests.
    */
   get mergedAndOpened(): Array<PullRequest> {

--- a/src/utils/duration-to-human.ts
+++ b/src/utils/duration-to-human.ts
@@ -1,8 +1,5 @@
 import { Duration } from 'luxon';
-
-function pluralize(str: string, val: number) {
-  return val === 1 ? str : str + 's';
-}
+import { pluralize } from './pluralize';
 
 /**
  * Returns a human-readable string representation of the duration.

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,0 +1,6 @@
+/**
+ * Naive pluralization
+ */
+export function pluralize(str: string, val: number): string {
+  return val === 1 ? str : str + 's';
+}

--- a/tests/fixtures/__recordings__/metric-MergedPRsMetric_4095279630/no-problems-for-test-repo-when-no-merged-PRs-are-found_212315159/recording.har
+++ b/tests/fixtures/__recordings__/metric-MergedPRsMetric_4095279630/no-problems-for-test-repo-when-no-merged-PRs-are-found_212315159/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "model: PullRequest/timeToMerge/PR: simple",
+    "_recordingName": "metric: MergedPRsMetric/no problems for test repo when no merged PRs are found",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "7c4de5ab60e075a443adcd336cefba90",
+        "_id": "e3187ba24442cd0fd368c7617c741138",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1224,
+          "bodySize": 273,
           "cookies": [],
           "headers": [
             {
@@ -38,7 +38,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1224"
+              "value": "273"
             },
             {
               "_fromType": "array",
@@ -55,24 +55,24 @@
               "value": "api.github.com"
             }
           ],
-          "headersSize": 403,
+          "headersSize": 402,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n  {\\n    repository(name: \\\"github-metrics-tests\\\", owner: \\\"bantic\\\") {\\n      pullRequest(number: 1) {\\n        mergedAt\\n        merged\\n        createdAt\\n        id\\n        number\\n        baseRefName\\n        author {\\n          login\\n        }\\n        timelineItems(first: 100, itemTypes: [PULL_REQUEST_REVIEW, REVIEW_REQUESTED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, REOPENED_EVENT, MERGED_EVENT]) {\\n          nodes {\\n            __typename\\n            ... on PullRequestReview {\\n              createdAt\\n              author {\\n                login\\n              }\\n              state\\n            }\\n            ... on ReviewRequestedEvent {\\n              createdAt\\n              actor {\\n                login\\n              }\\n            }\\n            ... on ReadyForReviewEvent {\\n              createdAt\\n              actor {\\n                login\\n              }\\n            }\\n            ... on MergedEvent {\\n              createdAt\\n            }\\n            ... on ConvertToDraftEvent {\\n              createdAt\\n            }\\n            ... on ReopenedEvent {\\n              createdAt\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n   \\n  \"}"
+            "text": "{\"query\":\"\\n  query {\\n    search(query: \\\"repo:bantic/github-metrics-tests is:pr merged:2021-05-04T18:00:00Z..2021-05-04T18:01:00Z sort:updated-desc\\\", type:ISSUE, first:100) {\\n      nodes {\\n        ...on PullRequest {\\n          number\\n        }\\n      }\\n    }\\n  }\"}"
           },
           "queryString": [],
           "url": "https://api.github.com/graphql"
         },
         "response": {
-          "bodySize": 623,
+          "bodySize": 102,
           "content": {
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
-            "size": 623,
-            "text": "[\"1f8b0800000000000003a5514d4fc3300cfd2f39b75252c686721bb4200e6da732a169084de96ab640938ec4dd87aafd775c18e232ed824fb6fcecf79eddb14aa162b2630e368dd7d8b8435f6ddaba2ee0b3058f7d69c0ada01a53ce221e89900f423e9c8a818c22c96fe62c38219844d742c0960e149e1d1043c947fd80ae68591a27fbbcbe15e5c3fe693ebb17f359c6b3f7f1751e7fecb238bd229c6d4d098e4911b0527928e02d530668d6288fd408986a71dd10a26375b3d2965aa5b2a897ec1830d4066a6de111c1f81e629b0a2879e9d86281870dd89f65933fbf056c35ec68\",\"ef051323c9456fe212b5473a0189b9cbd334c9a6494c7afec51a7179353ccfbad2b86ecbd0003abdf421d2dbe834e4ff57c4783229f2e7731ad2efd7265bb078d1f3e9d3c7d7631f5f9caff1e338020000\"]"
+            "size": 102,
+            "text": "[\"1f8b0800000000000003ab564a492c4954b2aa562a4e4d2c4ace00b1f2f253528b95aca2636b6b6b0186b7f0a820000000\"]"
           },
           "cookies": [],
           "headers": [
@@ -114,7 +114,7 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4999"
+              "value": "4996"
             },
             {
               "name": "x-ratelimit-reset",
@@ -122,7 +122,7 @@
             },
             {
               "name": "x-ratelimit-used",
-              "value": "1"
+              "value": "4"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,7 +170,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "DBAF:3AF4:3F19B0:C2DB32:60942BD8"
+              "value": "DBB2:4DDE:5EBB8F:B4EC66:60942BD9"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-06T17:48:08.745Z",
-        "time": 293,
+        "startedDateTime": "2021-05-06T17:48:09.013Z",
+        "time": 128,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 293
+          "wait": 128
         }
       }
     ],

--- a/tests/fixtures/__recordings__/metric-MergedPRsMetric_4095279630/value-is-correct-for-test-repo_3167715019/recording.har
+++ b/tests/fixtures/__recordings__/metric-MergedPRsMetric_4095279630/value-is-correct-for-test-repo_3167715019/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "model: PullRequest/timeToMerge/PR: simple",
+    "_recordingName": "metric: MergedPRsMetric/value is correct for test repo",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "7c4de5ab60e075a443adcd336cefba90",
+        "_id": "088b9bffe5111d7b828634ea9aaec62f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1224,
+          "bodySize": 273,
           "cookies": [],
           "headers": [
             {
@@ -38,7 +38,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1224"
+              "value": "273"
             },
             {
               "_fromType": "array",
@@ -55,24 +55,24 @@
               "value": "api.github.com"
             }
           ],
-          "headersSize": 403,
+          "headersSize": 402,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n  {\\n    repository(name: \\\"github-metrics-tests\\\", owner: \\\"bantic\\\") {\\n      pullRequest(number: 1) {\\n        mergedAt\\n        merged\\n        createdAt\\n        id\\n        number\\n        baseRefName\\n        author {\\n          login\\n        }\\n        timelineItems(first: 100, itemTypes: [PULL_REQUEST_REVIEW, REVIEW_REQUESTED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, REOPENED_EVENT, MERGED_EVENT]) {\\n          nodes {\\n            __typename\\n            ... on PullRequestReview {\\n              createdAt\\n              author {\\n                login\\n              }\\n              state\\n            }\\n            ... on ReviewRequestedEvent {\\n              createdAt\\n              actor {\\n                login\\n              }\\n            }\\n            ... on ReadyForReviewEvent {\\n              createdAt\\n              actor {\\n                login\\n              }\\n            }\\n            ... on MergedEvent {\\n              createdAt\\n            }\\n            ... on ConvertToDraftEvent {\\n              createdAt\\n            }\\n            ... on ReopenedEvent {\\n              createdAt\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n   \\n  \"}"
+            "text": "{\"query\":\"\\n  query {\\n    search(query: \\\"repo:bantic/github-metrics-tests is:pr merged:2021-05-04T18:00:00Z..2021-05-05T20:00:00Z sort:updated-desc\\\", type:ISSUE, first:100) {\\n      nodes {\\n        ...on PullRequest {\\n          number\\n        }\\n      }\\n    }\\n  }\"}"
           },
           "queryString": [],
           "url": "https://api.github.com/graphql"
         },
         "response": {
-          "bodySize": 623,
+          "bodySize": 142,
           "content": {
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
-            "size": 623,
-            "text": "[\"1f8b0800000000000003a5514d4fc3300cfd2f39b75252c686721bb4200e6da732a169084de96ab640938ec4dd87aafd775c18e232ed824fb6fcecf79eddb14aa162b2630e368dd7d8b8435f6ddaba2ee0b3058f7d69c0ada01a53ce221e89900f423e9c8a818c22c96fe62c38219844d742c0960e149e1d1043c947fd80ae68591a27fbbcbe15e5c3fe693ebb17f359c6b3f7f1751e7fecb238bd229c6d4d098e4911b0527928e02d530668d6288fd408986a71dd10a26375b3d2965aa5b2a897ec1830d4066a6de111c1f81e629b0a2879e9d86281870dd89f65933fbf056c35ec68\",\"ef051323c9456fe212b5473a0189b9cbd334c9a6494c7afec51a7179353ccfbad2b86ecbd0003abdf421d2dbe834e4ff57c4783229f2e7731ad2efd7265bb078d1f3e9d3c7d7631f5f9caff1e338020000\"]"
+            "size": 142,
+            "text": "[\"1f8b0800000000000003ab564a492c4954b2aa562a4e4d2c4ace00b1f2f253528b95aca281acd2dca4d422252bcb5a1d04c7d0108567501b5b5b5b0b00ef0b1dfd48000000\"]"
           },
           "cookies": [],
           "headers": [
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 06 May 2021 17:48:09 GMT"
+              "value": "Thu, 06 May 2021 17:48:08 GMT"
             },
             {
               "name": "content-type",
@@ -114,7 +114,7 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4999"
+              "value": "4997"
             },
             {
               "name": "x-ratelimit-reset",
@@ -122,7 +122,7 @@
             },
             {
               "name": "x-ratelimit-used",
-              "value": "1"
+              "value": "3"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,7 +170,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "DBAF:3AF4:3F19B0:C2DB32:60942BD8"
+              "value": "DBB1:5CC3:4909FD:C81106:60942BD8"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-06T17:48:08.745Z",
-        "time": 293,
+        "startedDateTime": "2021-05-06T17:48:08.785Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 293
+          "wait": 210
         }
       }
     ],

--- a/tests/fixtures/__recordings__/metric-TimeToMerge_3559889221/no-problems-for-test-repo-when-no-merged-PRs-are-found_212315159/recording.har
+++ b/tests/fixtures/__recordings__/metric-TimeToMerge_3559889221/no-problems-for-test-repo-when-no-merged-PRs-are-found_212315159/recording.har
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4981"
+              "value": "4988"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "19"
+              "value": "12"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,21 +170,21 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE54:4511:8F103:165724:6092E3A5"
+              "value": "DBBA:3D98:5E24B7:B31E59:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1121,
+          "headersSize": 1122,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.250Z",
-        "time": 135,
+        "startedDateTime": "2021-05-06T17:48:09.853Z",
+        "time": 146,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 135
+          "wait": 146
         }
       }
     ],

--- a/tests/fixtures/__recordings__/metric-TimeToMerge_3559889221/value-is-correct-for-test-repo_3167715019/recording.har
+++ b/tests/fixtures/__recordings__/metric-TimeToMerge_3559889221/value-is-correct-for-test-repo_3167715019/recording.har
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:48 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4988"
+              "value": "4998"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "12"
+              "value": "2"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,7 +170,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4A:5A03:85BC9:17D650:6092E3A4"
+              "value": "DBB0:7543:4B5C8F:D3D89E:60942BD8"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:48.485Z",
-        "time": 211,
+        "startedDateTime": "2021-05-06T17:48:08.779Z",
+        "time": 320,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 211
+          "wait": 320
         }
       },
       {
@@ -260,7 +260,7 @@
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
             "size": 535,
-            "text": "[\"1f8b08000000000000038d504d4bc34010fd2f73dec26e68d1ec4d49951e12217a2811299b64acabd94ddc4cfa41c87f77d7f6542a38a719e67df0de08b522057204875ddb6b6add315cddd034397e0fd853380dba2dd6777e87884762c617333e7f11b114918c7801ec8c00496e40069543455709fc46ce6f0341d75e2c4d9687a7e65e948f87e762fd208a75c6b3cf749f26ab459a7ccd3dce0ea64407326650aa1e737ccf9441cf35aa27ff60a006fa683d6284a6dd6aeb5fa5b2a42b98189036d8688b2b42d307886d6bf4cbeb089b0d1d3bb427b11c771af7e7c4582f7768c94bff\",\"9d437019c52187aa7c67d7cc2776e191fe96f80fe953a7d3db14e607d904e3eaa2010000\"]"
+            "text": "[\"1f8b08000000000000038d504d4bc34010fd2f73dec26e68d1ec4d49951e12217a2811299b64acabd94ddc4cfa41c87f77d7f6542a38a719e67df0de08b522057204875ddb6b6add315cddd034397e0fd853380dba2dd6777e87884762c617333e7f11b114918c7801ec8c00496e40069543455709fc46ce6f0341d75e2c4d9687a7e65e948f87e762fd208a75c6b3cf749f26ab459a7ccd3dce0ea64407326650aa1e737ccf9441cf35aa27ff60a006fa683d6284a6dd6aeb5fa5b2a42b98189036d8688b2b42d307886d6bf4cbeb089b0d1d3bb427b11c771af7e7c4582f7768c94b\",\"ff9d437019c52187aa7c67d7cc2776e191fe96f80fe953a7d3db14e607d904e3eaa2010000\"]"
           },
           "cookies": [],
           "headers": [
@@ -270,7 +270,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:48 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -302,15 +302,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4986"
+              "value": "4994"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "14"
+              "value": "6"
             },
             {
               "name": "x-ratelimit-resource",
@@ -358,21 +358,21 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4B:5038:5E123:F2A6F:6092E3A4"
+              "value": "DBB4:6800:1B6E67:492383:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1120,
+          "headersSize": 1121,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:48.707Z",
-        "time": 165,
+        "startedDateTime": "2021-05-06T17:48:09.110Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -380,7 +380,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 165
+          "wait": 211
         }
       },
       {
@@ -458,7 +458,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -490,15 +490,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4984"
+              "value": "4993"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "16"
+              "value": "7"
             },
             {
               "name": "x-ratelimit-resource",
@@ -546,7 +546,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4D:3AC4:82DAA:160B8D:6092E3A4"
+              "value": "DBB5:7008:635D1A:BA6E8E:60942BD9"
             },
             {
               "name": "connection",
@@ -559,8 +559,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:48.878Z",
-        "time": 171,
+        "startedDateTime": "2021-05-06T17:48:09.325Z",
+        "time": 229,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -568,7 +568,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 171
+          "wait": 229
         }
       },
       {
@@ -646,7 +646,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -678,15 +678,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4983"
+              "value": "4991"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "17"
+              "value": "9"
             },
             {
               "name": "x-ratelimit-resource",
@@ -734,7 +734,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4F:62D6:DCEA2:186941:6092E3A5"
+              "value": "DBB7:595F:40A9D7:8247F7:60942BD9"
             },
             {
               "name": "connection",
@@ -747,8 +747,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.052Z",
-        "time": 187,
+        "startedDateTime": "2021-05-06T17:48:09.558Z",
+        "time": 285,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -756,7 +756,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 187
+          "wait": 285
         }
       }
     ],

--- a/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-and-then-review-requested-then-closed_280315457/reopened_2876956121/recording.har
+++ b/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-and-then-review-requested-then-closed_280315457/reopened_2876956121/recording.har
@@ -72,7 +72,7 @@
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
             "size": 561,
-            "text": "[\"1f8b08000000000000038d514b4fc3300cfe2f3e675252b53072036d200e2952e13015a1295dcd086a9292a67b50f5bf93b09dc68496932d7f0f7ff100b5f412f8000e5bdb296fdd3e766ddf34057ef5d8f9d86a746bac6f430d094dd88466139abeb01b9e4c799694408e08e0def54860e550faf38494272c12541dc4c46cbe7b6aee58f5b07b2e17f7ac5ce434ff145b3113a9f81659c0995e57e880334aa0921d16f89e4b8d81ac65e7c38480ecfd870d90011abb56268c2a69bc5ac148c02b8d8d32f8e8517711626c8da1781d60b9f4fb16cd41acc08dc2ed3132d6f30d1a1fa4ff\",\"0992f1f43a0691abf069e7cc47f2c7c306bf8bc4a79c5e9561ff1305f17b870b963b9c657c1be3fb015fb880e1e5010000\"]"
+            "text": "[\"1f8b08000000000000038d514b4fc3300cfe2f3e675252b53072036d200e2952e13015a1295dcd086a9292a67b50f5bf93b09dc68496932d7f0f7ff100b5f412f8000e5bdb296fdd3e766ddf34057ef5d8f9d86a746bac6f430d094dd88466139abeb01b9e4c799694408e08e0def54860e550faf38494272c12541dc4c46cbe7b6aee58f5b07b2e17f7ac5ce434ff145b3113a9f81659c0995e57e880334aa0921d16f89e4b8d81ac65e7c38480ecfd870d90011abb56268c2a69bc5ac148c02b8d8d32f8e8517711626c8da1781d60b9f4fb16cd41acc08dc2ed3132d6f30d1a1f\",\"a4ff0992f1f43a0691abf069e7cc47f2c7c306bf8bc4a79c5e9561ff1305f17b870b963b9c657c1be3fb015fb880e1e5010000\"]"
           },
           "cookies": [],
           "headers": [
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4979"
+              "value": "4989"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "21"
+              "value": "11"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,20 +170,20 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE57:0483:3E152:D89FB:6092E3A5"
+              "value": "DBB9:16F3:436590:C99BDE:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1120,
+          "headersSize": 1122,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.511Z",
+        "startedDateTime": "2021-05-06T17:48:09.788Z",
         "time": 204,
         "timings": {
           "blocked": -1,

--- a/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-and-then-review-requested_2144229884/recording.har
+++ b/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-and-then-review-requested_2144229884/recording.har
@@ -72,7 +72,7 @@
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
             "size": 535,
-            "text": "[\"1f8b08000000000000038d504d4bc34010fd2f73dec26e68d1ec4d49951e12217a2811299b64acabd94ddc4cfa41c87f77d7f6542a38a719e67df0de08b522057204875ddb6b6add315cddd034397e0fd853380dba2dd6777e87884762c617333e7f11b114918c7801ec8c00496e40069543455709fc46ce6f0341d75e2c4d9687a7e65e948f87e762fd208a75c6b3cf749f26ab459a7ccd3dce0ea64407326650aa1e737ccf9441cf35aa27ff60a006fa683d6284a6dd6aeb5fa5b2a42b98189036d8688b2b42d307886d6bf4cbeb089b0d1d3bb427b11c771af7e7c4582f7768c94bff\",\"9d437019c52187aa7c67d7cc2776e191fe96f80fe953a7d3db14e607d904e3eaa2010000\"]"
+            "text": "[\"1f8b08000000000000038d504d4bc34010fd2f73dec26e68d1ec4d49951e12217a2811299b64acabd94ddc4cfa41c87f77d7f6542a38a719e67df0de08b522057204875ddb6b6add315cddd034397e0fd853380dba2dd6777e87884762c617333e7f11b114918c7801ec8c00496e40069543455709fc46ce6f0341d75e2c4d9687a7e65e948f87e762fd208a75c6b3cf749f26ab459a7ccd3dce0ea64407326650aa1e737ccf9441cf35aa27ff60a006fa683d6284a6dd6aeb5fa5b2a42b98189036d8688b2b42d307886d6bf4cbeb089b0d1d3bb427b11c771af7e7c4582f7768c9\",\"4bff9d437019c52187aa7c67d7cc2776e191fe96f80fe953a7d3db14e607d904e3eaa2010000\"]"
           },
           "cookies": [],
           "headers": [
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4980"
+              "value": "4990"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "20"
+              "value": "10"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,21 +170,21 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE56:738B:21392:825E0:6092E3A5"
+              "value": "DBB8:3D99:427432:CA3927:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1120,
+          "headersSize": 1122,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.320Z",
-        "time": 185,
+        "startedDateTime": "2021-05-06T17:48:09.592Z",
+        "time": 190,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 185
+          "wait": 190
         }
       }
     ],

--- a/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-as-draft-first_1408761293/recording.har
+++ b/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-as-draft-first_1408761293/recording.har
@@ -72,7 +72,7 @@
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
             "size": 671,
-            "text": "[\"1f8b0800000000000003a5524d6b834010fd2f7b5670251f746f69634a0f6ab052424a09ab4e932dbaa6eb982615ff7bc7d8522892163aa719e6cdbc798f6958265132d13003fbb252589a5357edeb3c8fe0b5860abbb200b3856c4639731d97dbcec87626319f08672ac6ee9a599f0826d0d460b1d480c4e18191e04e37a0325ae6cfbd63985ff3e4f678bf5e2df87a1538c1cb6c1cc6e97b187b9c70ba2e12304cb8164b6405113c07b2009a2d6485d4b098ac715712a26179b9559a5a89d4a852d65a0c5501b9d2708750541d44971950f2d8b0cd064f7bd0fdb20864765a9426\",\"82838237ef001a69f3051913c1af3a193225cb86b85beb07c5f2dbd29ee53782113f135c505721b94c7a6f42dff782d89b93e4ffb14e853b1d66dd2adcd5895d001a955636d26790fb64f1d711b3e5320a1f866ef0cfdff30753fb676a9fda2e3e00a186cf639b020000\"]"
+            "text": "[\"1f8b0800000000000003a5524d6b834010fd2f7b5670251f746f69634a0f6ab052424a09ab4e932dbaa6eb982615ff7bc7d8522892163aa719e6cdbc798f6958265132d13003fbb252589a5357edeb3c8fe0b5860abbb200b3856c4639731d97dbcec87626319f08672ac6ee9a599f0826d0d460b1d480c4e18191e04e37a0325ae6cfbd63985ff3e4f678bf5e2df87a1538c1cb6c1cc6e97b187b9c70ba2e12304cb8164b6405113c07b2009a2d6485d4b098ac715712a26179b9559a5a89d4a852d65a0c5501b9d2708750541d44971950f2d8b0cd064f7bd0fdb20864765a942682\",\"838237ef001a69f3051913c1af3a193225cb86b85beb07c5f2dbd29ee53782113f135c505721b94c7a6f42dff782d89b93e4ffb14e853b1d66dd2adcd5895d001a955636d26790fb64f1d711b3e5320a1f866ef0cfdff30753fb676a9fda2e3e00a186cf639b020000\"]"
           },
           "cookies": [],
           "headers": [
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:48 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4985"
+              "value": "4995"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "15"
+              "value": "5"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,21 +170,21 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4C:40EA:122EF8:1ED10C:6092E3A4"
+              "value": "DBB3:16F3:43653D:C99B03:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1122,
+          "headersSize": 1121,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:48.806Z",
-        "time": 213,
+        "startedDateTime": "2021-05-06T17:48:09.074Z",
+        "time": 256,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 213
+          "wait": 256
         }
       }
     ],

--- a/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-merged-then-first-review-requested_1042781935/recording.har
+++ b/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-opened-merged-then-first-review-requested_1042781935/recording.har
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:10 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4978"
+              "value": "4987"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "22"
+              "value": "13"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,7 +170,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE58:1782:113955:1DA550:6092E3A5"
+              "value": "DBBB:3AF2:325D4B:728856:60942BDA"
             },
             {
               "name": "connection",
@@ -183,8 +183,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.723Z",
-        "time": 197,
+        "startedDateTime": "2021-05-06T17:48:09.998Z",
+        "time": 226,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 197
+          "wait": 226
         }
       }
     ],

--- a/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-reopened_4077181017/recording.har
+++ b/tests/fixtures/__recordings__/model-PullRequest_1541417120/timeToMerge_2661047855/PR-reopened_4077181017/recording.har
@@ -72,7 +72,7 @@
             "_isBinary": true,
             "mimeType": "application/json; charset=utf-8",
             "size": 637,
-            "text": "[\"1f8b0800000000000003ad52c14ec3300cfd979c5b295dbb89e506ac200eed50d9612a4253da9a2da84947e28e8d6aff8ebb2121313481444e76fcfcf29ee38e551225131db3b06e9cc2c6eefa6cddd67506af2d38ec530d7609d525c56cc00781cf239f8f66c1480443115de4ccfb443081b6058f951624fed8c0c7821f1a544564c924de4eebaba0b8dd3ee4f39b209fa73c7db91c4e676598bc279c70a6d5055826428f15d24106cfa9d440bd5a3aa482c7648bab86101dab9ba532542aa44155b2bdc75069a895813b04ed7a88692aa0e0b1638b05eed6608e64f75f7e33d828\",\"7823deb326a2a83771faf452e1aa2d7c0d6855e97ca401924852e2902642daaea74912a7b3784297df4464d09020a8e20d183c2b20e0221ce7a70c7fb3419f3708ffdf467258965f9838eecefe69df9f0f6c4faa138a020000\"]"
+            "text": "[\"1f8b0800000000000003ad52c14ec3300cfd979c5b295dbb89e506ac200eed50d9612a4253da9a2da84947e28e8d6aff8ebb2121313481444e76fcfcf29ee38e551225131db3b06e9cc2c6eefa6cddd67506af2d38ec530d7609d525c56cc00781cf239f8f66c1480443115de4ccfb443081b6058f951624fed8c0c7821f1a544564c924de4eebaba0b8dd3ee4f39b209fa73c7db91c4e676598bc279c70a6d5055826428f15d24106cfa9d440bd5a3aa482c7648bab86101dab9ba532542aa44155b2bdc75069a895813b04ed7a88692aa0e0b1638b05eed6608e64f75f7e33d82878\",\"23deb326a2a83771faf452e1aa2d7c0d6855e97ca401924852e2902642daaea74912a7b3784297df4464d09020a8e20d183c2b20e0221ce7a70c7fb3419f3708ffdf467258965f9838eecefe69df9f0f6c4faa138a020000\"]"
           },
           "cookies": [],
           "headers": [
@@ -82,7 +82,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 05 May 2021 18:27:49 GMT"
+              "value": "Thu, 06 May 2021 17:48:09 GMT"
             },
             {
               "name": "content-type",
@@ -114,15 +114,15 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4982"
+              "value": "4992"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1620242782"
+              "value": "1620326888"
             },
             {
               "name": "x-ratelimit-used",
-              "value": "18"
+              "value": "8"
             },
             {
               "name": "x-ratelimit-resource",
@@ -170,21 +170,21 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "EE4E:356D:122654:1FE40B:6092E3A5"
+              "value": "DBB6:6733:1945A0:483D53:60942BD9"
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 1122,
+          "headersSize": 1121,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-05-05T18:27:49.026Z",
-        "time": 288,
+        "startedDateTime": "2021-05-06T17:48:09.337Z",
+        "time": 249,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 288
+          "wait": 249
         }
       }
     ],

--- a/tests/metrics/merged-prs.test.ts
+++ b/tests/metrics/merged-prs.test.ts
@@ -1,0 +1,29 @@
+import setupPolly from '../setup-polly';
+import { Interval, DateTime } from 'luxon';
+import MergedPRsMetric from '../../src/metrics/merged-prs';
+
+describe('metric: MergedPRsMetric', () => {
+  setupPolly();
+
+  test('value is correct for test repo', async () => {
+    let start = DateTime.fromISO('2021-05-04T18:00:00Z').toUTC();
+    let end = DateTime.fromISO('2021-05-05T20:00:00Z').toUTC();
+    let interval = Interval.fromDateTimes(start, end);
+
+    let metric = new MergedPRsMetric(interval);
+    await metric.run();
+
+    expect(metric.data.length).toBe(3);
+  });
+
+  test('no problems for test repo when no merged PRs are found', async () => {
+    let start = DateTime.fromISO('2021-05-04T18:00:00Z').toUTC();
+    let end = start.plus({ minutes: 1 });
+    let interval = Interval.fromDateTimes(start, end);
+
+    let metric = new MergedPRsMetric(interval);
+    await metric.run();
+
+    expect(metric.data.length).toBe(0);
+  });
+});

--- a/tests/reports/repository.test.ts
+++ b/tests/reports/repository.test.ts
@@ -28,7 +28,6 @@ describe('Repository Report', () => {
     expect(report.name).toEqual('Marvel/Avengers');
     expect(report.openedPullRequests).toEqual([]);
     expect(report.closedPullRequests).toEqual([]);
-    expect(report.mergedPullRequests).toEqual([]);
     expect(report.hotfixes).toEqual(0);
     expect(report.url).toEqual(
       'https://github.com/Marvel/Avengers/pulls?q=created:2021-03-08..2021-03-14'
@@ -59,7 +58,6 @@ describe('Repository Report', () => {
     expect(report.name).toEqual('Marvel/Avengers');
     expect(report.openedPullRequests.length).toEqual(15);
     expect(report.closedPullRequests.length).toEqual(19);
-    expect(report.mergedPullRequests.length).toEqual(14);
     expect(report.hotfixes).toEqual(0);
     expect(report.url).toEqual(
       'https://github.com/Marvel/Avengers/pulls?q=created:2021-03-08..2021-03-14'


### PR DESCRIPTION
Uses the same underlying graphql query that the TimeToMergeMetric uses.

Remove the `RepositoryReport#mergedPullRequests` property -- it does not
capture all merged PRs in the interval because it constrains to only PRs
that were created in the interval. It's possible for a PR to be created before
the start of the interval but merged during the interval -- PRs matching this
criteria were not being included.