### PR TITLE
enable debug logging during github-action step run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,3 +23,7 @@ inputs:
   slack-channel-id:
     required: true
     description: 'Slack Channel Id'
+  log-debug-messages:
+    required: false
+    default: false
+    description: Show all debug logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { setGithubArgs } from './utils/env';
 import { getInterval, Period } from './utils/date';
 import { fetchWorkflows } from './utils/api-requests';
 import WorkflowDurationMetric from './metrics/workflow-duration';
+import debug, { enableDebugging } from './utils/debug';
 
 /**
  * The function that runs the following workflow:
@@ -24,14 +25,21 @@ export async function run({
   githubToken,
   slackAppToken,
   slackChannelId,
+  logDebugMessages,
 }: {
   githubOwner: string;
   githubRepo: string;
   githubToken: string;
   slackAppToken: string;
   slackChannelId: string;
+  logDebugMessages: string;
 }): Promise<void> {
   setGithubArgs(githubOwner, githubRepo, githubToken);
+
+  if (logDebugMessages == 'true') {
+    enableDebugging();
+    debug.log = (...args) => console.log(...args);
+  }
 
   try {
     const slack = new WebClient(slackAppToken);
@@ -120,6 +128,8 @@ const slackChannelId =
   process.env.SLACK_CHANNEL_ID || core.getInput('slack-channel-id');
 const slackAppToken =
   process.env.SLACK_APP_TOKEN || core.getInput('slack-app-token');
+const logDebugMessages =
+  process.env.LOG_DEBUG_MESSAGES || core.getInput('log-debug-messages');
 
 run({
   githubOwner,
@@ -127,4 +137,5 @@ run({
   githubToken,
   slackAppToken,
   slackChannelId,
+  logDebugMessages,
 });

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,6 +1,9 @@
 import debugBase, { Debugger } from 'debug';
 
-export { Debugger } from 'debug';
+const debug = debugBase('github-metrics');
 
-const debug: Debugger = debugBase('github-metrics');
+export { Debugger };
+export function enableDebugging() {
+  debugBase.enable('github-metrics:*');
+}
 export default debug;


### PR DESCRIPTION
Adds the ability to enable the verbose debug logging in the logs shown by github when this action is run in a workflow.

It is the equivalent of setting the env var `DEBUG=github-metrics:*`. The messages are logged to stdout (using `console.log`), which causes them to show up in the output in Github's UI, like so:

![image](https://user-images.githubusercontent.com/2023/118025726-28d75400-b32e-11eb-928d-7043e0d4e0b6.png)
