### PR TITLE
[WEBCORE-803] Add WorkflowSuccess metric

### DIFF
--- a/src/metric.ts
+++ b/src/metric.ts
@@ -1,5 +1,5 @@
 import percentilesUtil from './utils/percentiles';
-export type MetricData = {
+export type NumericMetricData = {
   value: number;
   rawValue?: any;
 };
@@ -11,8 +11,11 @@ export function percentiles(ps: number[], metric: Metric): number[] {
 
 export interface Metric {
   name: string;
-  data: MetricData[];
+  data: any[];
   summary: string;
-
   run: () => Promise<void>;
+}
+
+export interface NumericMetric extends Metric {
+  data: NumericMetricData[];
 }

--- a/src/metrics/merged-prs.ts
+++ b/src/metrics/merged-prs.ts
@@ -1,12 +1,12 @@
 import { Interval } from 'luxon';
 import { fetchMergedPullRequestNumbers } from '../utils/graphql-queries';
 import debug, { Debugger } from '../utils/debug';
-import { Metric, MetricData } from '../metric';
+import { NumericMetric, NumericMetricData } from '../metric';
 import { pluralize } from '../utils/pluralize';
 
-export default class MergedPRsMetric implements Metric {
+export default class MergedPRsMetric implements NumericMetric {
   debug: Debugger;
-  data: MetricData[];
+  data: NumericMetricData[];
   didRun: boolean = false;
   name = 'Merged Pull Requests';
   constructor(public interval: Interval) {
@@ -26,8 +26,7 @@ export default class MergedPRsMetric implements Metric {
     let numbers = await fetchMergedPullRequestNumbers(this.interval);
     this.debug(`found merged PR numbers: %o`, numbers);
 
-    let data: MetricData[] = numbers.map((number) => ({ value: number }));
-    this.data = data;
+    this.data = numbers.map((number) => ({ value: number }));
     this.didRun = true;
   }
 }

--- a/src/metrics/time-to-merge.ts
+++ b/src/metrics/time-to-merge.ts
@@ -3,11 +3,11 @@ import { fetchMergedPullRequestNumbers } from '../utils/graphql-queries';
 import { loadPullRequest } from '../models/pull-request';
 import debug, { Debugger } from '../utils/debug';
 import { millisToHuman } from '../utils/duration-to-human';
-import { Metric, MetricData, percentiles } from '../metric';
+import { NumericMetric, NumericMetricData, percentiles } from '../metric';
 
-export default class TimeToMergeMetric implements Metric {
+export default class TimeToMergeMetric implements NumericMetric {
   debug: Debugger;
-  data: MetricData[];
+  data: NumericMetricData[];
   name = 'Pull Request Time-To-Merge';
   constructor(public interval: Interval) {
     this.debug = debug.extend('metrics:time-to-merge');
@@ -31,7 +31,7 @@ export default class TimeToMergeMetric implements Metric {
     let numbers = await fetchMergedPullRequestNumbers(this.interval);
     this.debug(`found merged PR numbers: %o`, numbers);
 
-    let data: MetricData[] = [];
+    let data = [];
 
     for (let number of numbers) {
       let pr = await loadPullRequest(number);

--- a/src/metrics/workflow-duration.ts
+++ b/src/metrics/workflow-duration.ts
@@ -6,11 +6,11 @@ import {
 } from '../utils/api-requests';
 import debug, { Debugger } from '../utils/debug';
 import { durationToHuman, millisToHuman } from '../utils/duration-to-human';
-import { Metric, MetricData, percentiles } from '../metric';
+import { NumericMetric, NumericMetricData, percentiles } from '../metric';
 
-export default class WorkflowDurationMetric implements Metric {
+export default class WorkflowDurationMetric implements NumericMetric {
   debug: Debugger;
-  data: MetricData[];
+  data: NumericMetricData[];
   didRun = false;
   workflowId: number | string;
   workflowName: string;
@@ -47,7 +47,7 @@ export default class WorkflowDurationMetric implements Metric {
     });
     this.debug(`found ${runs.length} workflow runs`);
 
-    let data: MetricData[] = [];
+    let data: NumericMetricData[] = [];
     runs.forEach((run) => {
       this.debug(`run #${run.id} duration: ${durationToHuman(run.duration)}`);
       data.push({ value: run.duration.toMillis() });

--- a/src/metrics/workflow-success.ts
+++ b/src/metrics/workflow-success.ts
@@ -1,0 +1,66 @@
+import { Interval } from 'luxon';
+import {
+  fetchWorkflowRuns,
+  WorkflowData,
+  FetchWorkflowRunsOptions,
+  STATUS_COMPLETED,
+} from '../utils/api-requests';
+import debug, { Debugger } from '../utils/debug';
+import { Metric } from '../metric';
+
+export default class WorkflowSuccessMetric implements Metric {
+  data: {
+    status: string;
+    conclusion: string;
+  }[] = [];
+  debug: Debugger;
+  didRun = false;
+  name = 'Workflow Success Rate';
+
+  constructor(
+    public interval: Interval,
+    public workflowData: WorkflowData,
+    public workflowRunOptions?: FetchWorkflowRunsOptions
+  ) {
+    this.debug = debug.extend('metrics:workflow-run-success');
+  }
+
+  get summary(): string {
+    if (!this.didRun) {
+      throw new Error(`Cannot get sumary before calling run()`);
+    }
+    if (this.data.length === 0) {
+      return `No completed runs found.`;
+    }
+
+    let success = this.data.filter((d) => d.conclusion === 'success').length;
+    let total = this.data.length;
+    let percent = (100 * (success / total)).toFixed(1);
+    this.debug(`Found ${this.data.length} total runs`);
+    this.debug(
+      `Non-success runs: ${JSON.stringify(
+        this.data.filter((d) => d.conclusion !== 'success')
+      )}`
+    );
+    return `${percent}% Succeeded (${success}/${total})`;
+  }
+
+  async run(): Promise<void> {
+    await this.load();
+    this.didRun = true;
+  }
+
+  private async load(): Promise<void> {
+    let options = {
+      ...this.workflowRunOptions,
+      status: STATUS_COMPLETED,
+    };
+    let { runs } = await fetchWorkflowRuns(
+      this.interval,
+      this.workflowData.id,
+      options
+    );
+    this.debug(`Found ${runs.length} workflow runs`);
+    this.data = runs.map(({ status, conclusion }) => ({ status, conclusion }));
+  }
+}

--- a/tests/fixtures/__recordings__/metrics-WorkflowSuccess_2784406732/counts-successful-and-total-runs-in-the-interval_3023793857/recording.har
+++ b/tests/fixtures/__recordings__/metrics-WorkflowSuccess_2784406732/counts-successful-and-total-runs-in-the-interval_3023793857/recording.har
@@ -1,0 +1,196 @@
+{
+  "log": {
+    "_recordingName": "metrics: WorkflowSuccess/counts successful and total runs in the interval",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.0"
+    },
+    "entries": [
+      {
+        "_id": "579de8eed1ab8f2fa4739351ef94dc65",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "octokit-rest.js/18.5.3 octokit-core.js/3.4.0 Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/16.5.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token *****"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "api.github.com"
+            }
+          ],
+          "headersSize": 0,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "per_page",
+              "value": "100"
+            }
+          ],
+          "url": "https://api.github.com/repos/bantic/github-metrics-tests/actions/workflows/source-of-run-data.yml/runs?per_page=100"
+        },
+        "response": {
+          "bodySize": 9764,
+          "content": {
+            "_isBinary": true,
+            "mimeType": "application/json; charset=utf-8",
+            "size": 9764,
+            "text": "[\"1f8b0800000000000003ed9d6d73daca15c7bf8a86beac6d090930307327cd5cb7693a03bec9d8b9b7ed743c8b5840b690a81e8c1d8dbf7bcf59090c5c8c502491a6fdbfb9b921d2d9d53eefd9dffe4f\",\"d288fc48b877b61f7b51a3df6c9e35967ef03071fde55d107b61a3ffcfa4e18c1bfdaed9359b8661f5ce1a9e98cb46bff16bf69cf6999ed37e0ea488a47623c348bb129168d073fe58def1bb8dc1d59f9faeddf1a33d8fe6a30f3debd6fb125f5f7d6c0deeffbc1c5c0ddaf4f04c8af1dd28109e3da317e6228c64b0fa399c09fa4d74a51819b66159d6a5d59af4ecf1a59023cbb62713c36c5bbd9edd6ed956cba6b728e7775e3c1f9109f549f251f2d7bd7edad8091722a2a4ce1a6124a298beb361fbf3852b2339a61f6ddfb3dd38747c8ffe218c6d5b8621fdbc2e1a55223de3b2ddb1e8e199b41feec2d889d2cf353bbd5ec7303be6e5f6bf6d95c7f2fa61e8ffe3d761706b7d598c3fdc3e0fef1fdac3fbf7f4e7478b928a0397929e45d122ecebba58381753279ac5a30bcaa61ec8851fea23e1458eada7bf9fcf65143876781e510d84bab023ca7ca8731deaebbae3028de6eeddb6f10dc3df647211bbee5d20ff1d73cad460fe459fad5ac3f84e70a99b86d93c37dae74de3a669f5ad66bf6dfd83bf70317ef319ab6fb4f8997b7f14eee4b6a2a2d0d934a5e0fad3ba5260d3dc96369a47c95a55a6ce554b0bf5d76646898820722654e9757dcbda3e7f107552b9db88aaaa96d438a51248eec5250b6c7f37a0fe43b6298d757fae2899953dea72e9e04069a8818d3aeddca1be908ea54586b22890d9202a3aedb1ec88e6e4d236bbd210d6444c9ab6b4c7cdae316a9b524ebab2d36a3629cd390d5762ca83f4400653a9710fd5b21eaafda179a94d027fae659d3dfb438cc7e7f249f01878befa0e321539642ca29f373ab2d1bb31a9231bfdb6c19d54c4d1cca7913659cd0c3ffbc1b3f6173f089f231e61e55c383c98d9f4f3c524fdf94f53fe9107b3c60b0fb75c3c3ce2bf1af9e0447f8d471baf7b3e0d7beef39f5e87abc60bbdabc6422722dbabe2b5da6db36935dbc6ce14b4bc76ffe6da1f7a5fc56f9f1f6defe1ebf0e6f6797033781adebcff8912cae6b57de329fdeb8447b9ec9103c3243db9089c471ad91afd89704379d6f0975efa653420383ca1a4afd3933c8dd0e84873c8e6dcf0a9f3e5b7a16bdf7f5c0eee079c3141e644b0db17d48f61362dc4a10c68d28a689e533344acb3dd778f3fb5e8fd699059509331fd70b0b9b3a9d5e442cf1e336170f1f82ead19e8cddd6c6ecf5c9bc6f5f53bebf71d6f5af87d7a27d1fd6826a98428eb2ffcc10ecd44050ca9e7139a49c388162c6c819a7c10d004767449e9d91b9415aeee97444dd2ca543c0aedc059a809b988c1cdf7c88e1f4c85e77c1545edd07b3c0da97e522079f53cbda7d64e455e4c5f4874d50dec672e8240dad279a4e22c6c6ce74db2153d2f7860bba5aae6c2e5459718cfb95fa9ee4623c2312d76efaa89ec8de5baae28915f3e87da92965d9a7c5a489b1634daa3706999a34533116934556923a951a31b6b34ac69bcf2a2c6a80dd2951859a35f1fd6c3c0c1a694bba2cbace55444ae19ea73c10357eb837c2e6d8b6d243afd37eb34368d0162e4078246e3d2c6b78c25fae65fb9494552cc4ba7a18c90b199ef3f9436a68c9031270c6379544bcfaf2d652bd4575d2addd3f0e71fd391f2cda756c89c084367ea4959ba10d686127d3518a79bbaf2a65776123dfd3fd50a44f9d53bdb205323b782bd06ad1d746528d169d39a4e45d15d15b964cb6c67cb702027a56b8c0db39db5615e71566255195a9b4df7d9e52dafece84956c2aef0a631ad764be7796d885a03cfe653f135773d93dfc75e2d91595ea205ce28ae66807cb5c5394e970be4f3285d101ba65e0dabf5cbe1f5c31185b1b1a651c5c1ebfed2f9cdcc6c758d8a4c73efd835cf7fcf5f13e517c6ca4ea2bf8eebe9e491fd4bd9d2ce668f7de9647b850a8a5eed39423df92339d4663ce2\",\"51720b11c8b299cfcce8c948d0aaeee2e222e19d342730e73d6de99ca756c89c08ec192d4ecbe63759d9a115d65c446a0330e1ec8e6943e0fa625c3ac76b436434addab2794ead6cb63ff61494cea832b26975eeb8b436f6bd0a6a6d6d69d3bee793f7cbb18fd91ae577cb2d63c9bbd0216fd79970dd336ad5e46f75a89dd32a9f6b9616bbb27c69a556e873c8adce5603e94a6af2a56b616527d1d32ded98bc27fe732523d7862976df2817972a58f861e087811f667d4eb3e5ed821f46cfbc2eca4379d8870a3f4c81c33ef861368f3ee187e1f3df9543077e18f861e087a11e013fcc061eb27926053f4ce6cf811f4611463b2411fc30bb25023f4ca8bf7a74e087c941f14ee58779397b25358d5edb32ab2535dfb7873783679a2cea233509d8f91ea466b36d52ca9b98de51a42661431f97541ee5cef57f4f6aaabae372ae8ed45c992c4c6ab6ba79a4a6d937dab5919a2adfb5929a690a272135b99951b5d6476aa6df720252334da86652334d04a426484d909a6f5c0300a949e329484d75f24625710c13b67522015213a42648cd63ba4d3e350052f3f5f219484d909aa9c79d6e5612be0c5213a4667a2d955144023e416aee38d9416a1eb8cb0c5233d4416aee399a02a999ab030052734344013766d31bb7b831fb3b450d909a3b77098e130521af13484d909adf2852035213a4266ecc668a4dea822f484d909adb425e203537b0d57d3759716376a5f9065213a4e6eff95d909a478b267e1f52d36ab5aa2635075f3f316a561ba94922a0df03d4343add6f013597c3fb693da026555dd5a0666ab238a8992ba969f65b75829a94ef9a414d4ee124a02637b39a414dfe9693809a9c50eda02627025013a026404d809aaff7fa21a9c93aac1b62aaa96c37404d486abeaddb0e29074839ec4af943ca01929ae416c701c1cad10929074839ec15f056529d2c4709290748391c132607520e90722880ef9cea8000929a086dc2e154006a02d44468936363de21b4c9c6b600a14d781fc0c778086d82d02659a8108436c9043310da24e0b16113ae2c1b4b01a02640cd2383f302d404a80950b34474eb53f961b625358d6ea77250f36aaaa41eeb0a7edefd1ea066bbd76b1b1475bda0a2e60dc53fbf79ff44c551bda226555dd5a0666ab230a8692908f350ecf3557cf45a629f1b3dca77cda026a7700250336d66bcc3ab2df6795a5a270135b9d06a07353911809a0035016a02d404a8e95c6c881c00d484928362268edcc303d404a8095073b30d40c9014a0e3b3d02a026404d809aba586c2d35f3c5a471408003021c10fc0007040035016a02d4dc2bff07454d286adafb177f0035016adaabcb7c69f815809acca301d404a8e94d6331958a4ea4b515404d809aec58dd0d9cb2bae85a965ac585d9d181c823f0c3c00f033fcc0fe0877905353b66cb6cf5887bf4c45c36fa8d5ffde061425729b5cfb1176a3f07524452bb9161a45d8948d02cbb15ebfbe9da1d3fdaf3683efad0b36ebd2ff1f5d5477370ffe97978f5a0a41eeb02352fcb829a13e1b87120298fcbec8bef9c71a3dfed1997ed8eb50d63f23f989d9ed5b17a0687892f046a7e1dde0fda832b150abe5a5033ab3a2ee6aa429fbf9a3c16d4347a37a6d5b7ccbef576e8f3f533edba1435b37cd7086aae52a81fd4cc9a19eff06a023557df523ba8b94aa85650739508404d809a0035016a02d404a8b9c159d13c8a905b0035f79eb9e5932508b985905b0035016a02d47c5b83194a0e507238f216080e0870408003821fe08000a026404d809a7b378d0035016a02d4cc779d4051138a9a7a24a6003527145f01a026404da268423df3968c24404d809ae1eb61251fd1ec78196ddf8b780ed1933f2e44347ba1a3accc815201c6ba1081d4939108e5cbc5c545c2a4162730\",\"9701d1d465eda75614c262cf9c4759d65eb2b2435761e6227a4948966bc2d95d0724299b02229b20b2498153d2d32b6a2accc9a078de55839aef39d6776da02649809e3cf4391174dd769710d1c2a0666b7833b5a8386a00350d1561be525053992c0e6a1a6f2a6aa6a066abd9379afc4c0d8a9a592bae1bd4348c13286a66cd4ccd7291331176547ade241b8eef857a40f0b5de3557a5751a50930aad7e50931201a8095013a026404d809a0035016abe310ee4fbd7a1a809454d286a4251738fe310a1cf11fa7c4fb300a8095013a0e65ea8277fb98503021c10fc171e1000d404a8095073ef980e5013a02640cdfc950d404d809a003523468a006aeaae00a80950732e771dab50d47cfb063440cd95bf15a0e65aa89bc12c9a4fbc784eacb7426b1d970616dfab00af5d5bdab4eff9442139b6500851591e76cb58f22e743c5b9e09d73d236e38726c878064c79bf267b96224ddd2e9a556e873488692adae00cbb2dff15d40cd66fb92e8c34a41cda7e18dcd64626da066fbfb809aed6ebb68e87356d46c5e5fdd561ffa9c783baeba8a41cdcc64415093c29a7772404dabd53794ea663da026e7bb5e5053a57012454d6e66f5829aea5b4e016aaa84ea063555220035016a02d47c03d0daf42e1f3961d063139f9df574f7eff0ba66cb75bd7e67fd3eadbc0abf4fef24ba1fcd6470c7d6798d3575e842620143eaf984621485118965b3050eb911c871011bd91b9495a547b9e08b5c0b5f998a47a11d388b2356af5ba5b3f51ed9f1290688e77c3d66158c03021c10e0800007040bfff03d5c84dca23bc85072c00181f28be3802093438592c3dad7092587c333080e087040f03b790f1c10380580ca1ffd8000a026404d809a0035e59d18cf1dafd19f0897b4974a688290b30b914d0acc20b8308b0bb3b830bbcb75a918ea6b7d4adac8ddb1a7e7b0473fdf65a86ea0929d2dc30c58566118a026fc301b3739e187811fe6e86bad50d48c941717a02640cdb0afeb62b12542943fb3ffe87e98add0e74dd322eeb15a5073407422032175853e6f9505355376cc9563ca6591e0e7ad0ec7892faca9690cef552cf8ca3535b9f2b8a02bd4d4cc4c1646355b661eaa69f69bbd1a514d2a8a9a514d4ee124a8263733aad61a3535b9964f836a7242b5a39a9c08504da09a4035816a4253139a9ad0d47c631cc8dfdce0880047043822c011c11ef144686a4253734fb380a62634358f3e7c9823e8d696ae083435a1a95900e039959603504da09a4035816a02d52c02e85368ce078ef5cc3e94b29417fc30f0c3c00f033fcc9e0d37fc30f0c3ec6916f0c3c00f033fccde357bfeb117fc30f0c3fc17fa61b6504da3dbaa5a5373797df5a9564d4dab2caa19c6b62d43de55150135ad769bc2ae170635bf0e6f6ecd3a404daeba8a41cdcc646150d3541066bc188b8864cb44d4e8374cc36c9e1bedf334f8b965f62d1520bd1e4d4dce77bda0a64ae124a02637b37a414df52da7d0d45409d50d6aaa44006a02d404a8f906a0054d4d1a4fa1a9a9362c5412a9eede615ff2968667fa42a22f02e751d8cfa98ebc2d9d479aeb0b1b0be4d69b949fe8792169c1704bf2a95c4f4e8403021c107ce3961b41b710740b9a9a08ba95dec686a6263435473b079ed0d484a626055d5302f9874b025a0ed072f8bfd47200a8095013a0e6de1d28629b20b609629be4af9de087811f067e18f861e087d9ba99074d4d686a1e8d534253139a9a3bce4bc436297232fa3fa5a969745a245159a9a6e67278ffc96082b02e4d4db32ca839118e1b0792f25804d434bb1d4ab930a8f97c7df5f7674aaa72454dae3a2ee60a153533938541cd542df310a8d9ec5b2a407a4da0261545cda026a7701250939b1915548d8a9a5ccba7013539a1da414d4e04a026404d809a00\",\"35a1a809454d286abe310ee4fbd7a1e4002507283940c961cf957d283940c9614fb3809203941c8e3e7a80a2e61c8a9a3beb8bb9e3528833df93147dd28be72319f04530cf8f9c89638bc8f1bdd2fa645bc69277a1e3d9f24cb8ee1909bc468eed2c28196fcac9a6aefdc377d8f257d13ffa0101404d809a0035016ae2c26c916361286a6eac84016a02d404a8095013a026404d9d5c87b31817662fd27238da5b025013a02640cd3e016e7bb762fffb7e986d454da34bf1bcab05350757534510d6056a36cb829adfa6a8d9347ac4b41606359f06570fccad560f6a52d5550d6aa6260b829a46bf9daba8d9ec37db35829a94ef9a414d4ee124a02637b39a414dfe9693286a7242b5839a9c08404d809a0035df58d2405193c653286a4251b3dff8e573a82dc96fa0c9a785b449fe5b7b146e2c432d9a8948a3a94a1b498dfacb5823bfbbc61b453ac2d506a9b7855a117be31bfd89704359764597592b7d0c8d03021c10acef29a702b7bc7c0c4367ea4959ba79ad0d253acf238c338c02e1d136a8b4e9959d444fff8f6d47625ada2edbe06cbafea8b42de61395a1440f67827348bfdc55914b453e524eb70c0772524996d9ceda701454d00e006a02d4dce36f07a80950f3e8a307809a0035770fec006ac6a3233b10429f73488788c22f641b307fe95114867ed220c7ace351548691f088bca5459a336ef429a613c5def2fcb1bce3bf3606579f3a5f7e1bbaf6fdc7e5e07ef013af92c99c0876c15cf563989dabf2a2d7f6d5a1a9aaa65867bbef1e7f6227ed34c82ca804e887834e7ef861a884e087811f067e981c316f5c98c585595c98c585d93d1b6ef861e087d9d32ce087811fe6c86d24ed62e886a2d4939108e5cbc5c545c2a416bbb6e732989677eba756787715d8330abbb7bbbd5a6c69c9e4f376886c82c826ff97914d5efef5f21f62ad9ead6bca0100\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "GitHub.com"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 10 May 2021 00:00:00 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, max-age=60, s-maxage=60"
+            },
+            {
+              "name": "vary",
+              "value": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"5377a8c34a89b092dcfda98e7fbc78f1bffb286e670524cb22e9c19244ea2983\""
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": ""
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": ""
+            },
+            {
+              "name": "x-github-media-type",
+              "value": "github.v3; format=json"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "5000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "5000"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1630000000"
+            },
+            {
+              "name": "x-ratelimit-used",
+              "value": "0"
+            },
+            {
+              "name": "x-ratelimit-resource",
+              "value": "core"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains; preload"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "origin-when-cross-origin, strict-origin-when-cross-origin"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "D403:6EA6:6FD290:1B2A629:60997471"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 0,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-05-10T00:00:00.000Z",
+        "time": 150,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 150
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/tests/metrics/workflow-success.test.ts
+++ b/tests/metrics/workflow-success.test.ts
@@ -1,0 +1,32 @@
+import { Interval, DateTime } from 'luxon';
+import setupPolly from '../setup-polly';
+import WorkflowSuccess from '../../src/metrics/workflow-success';
+
+/**
+ *  These tests rely on the source-of-run-data.yml Workflow Runs:
+ *  https://github.com/bantic/github-metrics-tests/actions/workflows/source-of-run-data.yml
+ * 
+ *  To view the source data locally, install `gh` and `jq` and run:
+    gh api -X GET /repos/bantic/github-metrics-tests/actions/workflows/source-of-run-data.yml/runs \
+      -f 'status=success' | jq '.workflow_runs[] | {status, conclusion}'
+ */
+
+describe('metrics: WorkflowSuccess', () => {
+  setupPolly();
+
+  const workflow = {
+    id: 'source-of-run-data.yml',
+    name: 'name does not matter to this test',
+  };
+  const start = DateTime.fromISO('2021-05-09T22:30:00Z');
+  const end = DateTime.fromISO('2021-05-10T13:40:00Z');
+  const interval = Interval.fromDateTimes(start, end);
+
+  test('counts successful and total runs in the interval', async () => {
+    let metric = new WorkflowSuccess(interval, workflow);
+    await metric.run();
+    expect(metric.data.length).toBe(11);
+    expect(metric.summary).toContain('8/11');
+    expect(metric.summary).toContain('72.7%');
+  });
+});


### PR DESCRIPTION
Stacked on https://github.com/Addepar/github-metrics/pull/13, which was merged, so this is *ready for review*.

The metric counts successful workflow runs and reports a summary with percent and absolute values, for example:

`87.5% Succeeded (7/8)`

This PR refactors the `Metric` interface into `NumericMetric`, and creates a new, more generic `Metric` interface. The `WorkflowSuccess` metric is the first one that doesn't have an associated array of numeric data.

Note that this PR only adds the metric, it does not include it in `src/index.ts`, so it doesn't show up yet in any report. We want to be able to constrain the workflow(s) and associated branch(es) that this success metric is run for. That work will come in a follow-up PR.