### PR TITLE
Upgrade deprecated github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: volta-cli/action@v3
 
       - name: Node Modules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-build-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
actions/cache v2 (and v3) will be removed soon, see https://github.com/actions/toolkit/discussions/1890
The upgrade to v4 is back-compatible.

actions/checkout v3 is old, and the v4 upgrade is back-compatible.